### PR TITLE
在Create方法中初始化RanderPass以防止高版本Unity报错

### DIFF
--- a/Assets/URPLearn/GrassGPUInstances/Scripts/GrassRenderFeature.cs
+++ b/Assets/URPLearn/GrassGPUInstances/Scripts/GrassRenderFeature.cs
@@ -10,7 +10,7 @@ namespace URPLearn{
     public class GrassRenderFeature : ScriptableRendererFeature
     {
 
-        private GrassRenderPass _pass = new GrassRenderPass();
+        private GrassRenderPass _pass = null;
 
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
@@ -22,6 +22,7 @@ namespace URPLearn{
 
         public override void Create()
         {
+            _pass = new GrassRenderPass();
         }
 
 


### PR DESCRIPTION
若在构造时初始化RenderPass，Unity2020.2会报错